### PR TITLE
Add sigma rules documentation

### DIFF
--- a/content/docs/markdown/integrations/sigma-rules.md
+++ b/content/docs/markdown/integrations/sigma-rules.md
@@ -1,0 +1,36 @@
+# Sigma to Kibana Conversion Script
+
+## What it does
+
+Downloads the latest Sigma detection rules from GitHub and converts them to Kibana-compatible format. The script handles Windows, macOS, and Linux rules, then optionally uploads them directly to your Kibana instance.
+
+## Prerequisites
+
+- Python 3, pip, curl, jq, and unzip
+
+## How to use it
+
+```bash
+cd ~/LME/scripts/sigma/
+chmod +x convert_sigma_to_kibana.sh
+./convert_sigma_to_kibana.sh
+```
+
+## What happens
+
+1. Downloads latest Sigma rules from official repository
+2. Converts rules for all three platforms (Windows/macOS/Linux)
+3. Creates NDJSON files in `output/` directory
+4. Prompts to upload directly to Kibana or do it manually
+
+## Manual upload (if needed)
+
+1. Open Kibana at `https://localhost:5601`
+2. Go to **Security → Rules → Import Rules**
+3. Upload the files from `output/` directory
+
+## Important notes
+
+- All rules are **disabled by default** for security
+- Review and enable rules individually based on your environment
+- Script downloads fresh rules each time it runs


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

Adds the sigma conversion script usage documentation

## 🧪 Testing ##

Functionality should be tested in PR into main LME github


