### PR TITLE
Fix spelling of 'password' in syslog documentation

### DIFF
--- a/content/docs/markdown/logging-guidance/syslog-forwarding.md
+++ b/content/docs/markdown/logging-guidance/syslog-forwarding.md
@@ -118,7 +118,7 @@ This guide provides instructions for setting up syslog forwarding to the LME ser
 
 4. Click on the **dataview logs drop-down menu** and then select **logs-***.
 
-5. In the Filter your data search bar, search for SSH-related entries by typing **message:("Failed passowrd" OR "invalid user" OR "authentication failure")**.
+5. In the Filter your data search bar, search for SSH-related entries by typing **message:("Failed password" OR "invalid user" OR "authentication failure")**.
 
 6. Confirm the failed login attempts were captured.
 
@@ -126,6 +126,6 @@ This guide provides instructions for setting up syslog forwarding to the LME ser
 
 1. Build a ***metric visualization for failed login attempts***.
 
-2. In the Filter your data search bar, type **message:("Failed passowrd" OR "invalid user" OR "authentication failure")**.
+2. In the Filter your data search bar, type **message:("Failed password" OR "invalid user" OR "authentication failure")**.
 
 3. Add the ***visualization*** to the dashboard.


### PR DESCRIPTION
<!-- GitHub renders PRs such that soft line breaks are treated as hard
line breaks.  In order to make this template render as expected we
therefore have to avoid soft breaks and therefore will offend
markdownlint with long lines.  This is the reason for the markdownline
disable directive just below.

For more details see:
https://github.com/github/markup/issues/1050#issuecomment-294654762 -->
<!-- markdownlint-disable MD013 -->
# <!-- Use the title to describe PR changes in the imperative mood --> #

## 🗣 Description ##

<!-- Describe the "what" of your changes in detail. -->
<!-- To avoid scope creep, limit changes to a single goal. -->

Fixed spelling of 'password' in the syslog forwarding docs page.

## 💭 Motivation and context ##

<!-- Why is this change required? -->
<!-- What problem does this change solve? How did you solve it? -->
<!-- Mention any related issue(s) here using appropriate keywords such -->
<!-- as "closes" or "resolves" to auto-close them on merge. -->

I was going through the docs to enable syslogs and found the spelling for 'password' to be 'passowrd' when discussing the data search filter.

## 🧪 Testing ##

<!-- How did you test your changes? How could someone else test this PR? -->
<!-- Include details of your testing environment, and the tests you ran to -->
<!-- see how your change affects other areas of the code, etc. -->

I did not test/verify by spinning up a local version of the docs.

<!--
## 📷 Screenshots (if appropriate) ##

Uncomment this section if a screenshot is needed.

-->

## ✅ Pre-approval checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- Draft PRs should have one or more unchecked boxes. -->
<!-- If you're unsure about any of these, don't hesitate to ask. -->
<!-- We're here to help! -->

- [x] This PR has an informative and human-readable title.
- [x] Changes are limited to a single goal - *eschew scope creep!*
- [x] *All* future TODOs are captured in issues, which are referenced in code comments.
- [x] All relevant type-of-change labels have been added.
- [x] I have read the [CONTRIBUTING](../blob/develop/CONTRIBUTING.md) document.
- [x] These code changes follow [cisagov code standards](https://github.com/cisagov/development-guide).
- [x] All relevant repo and/or project documentation has been updated to reflect the changes in this PR.
- [x] Tests have been added and/or modified to cover the changes in this PR.
- [ ] All new and existing tests pass.
- [ ] Bump major, minor, patch, pre-release, and/or build versions [as appropriate](https://semver.org/#semantic-versioning-specification-semver) via the `bump_version` script *if* this repository is versioned *and* the changes in this PR [warrant a version bump](https://semver.org/#what-should-i-do-if-i-update-my-own-dependencies-without-changing-the-public-api).
- [ ] Create a pre-release (necessary if and only if the pre-release version was bumped).

## ✅ Pre-merge checklist ##

<!-- Remove any of the following that do not apply. -->
<!-- These boxes should remain unchecked until the pull request has been -->
<!-- approved. -->

- [ ] Revert dependencies to default branches.
- [ ] Finalize version.

## ✅ Post-merge checklist ##

<!-- Remove any of the following that do not apply. -->

- [ ] Create a release (necessary if and only if the version was bumped).
